### PR TITLE
feat: replace stack_file & compose_file with deploy_file, improve SCP…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,23 @@ This GitHub Action deploys Docker Compose or Docker Swarm services over SSH. It 
 
 ## Inputs
 
-|  Input Parameter          |  Description                                                | Required     | Default Value        |
-| ------------------------- | ----------------------------------------------------------- | :----------: | -------------------- |
-| `ssh_host`                |  Hostname or IP of the target server                        | ✅          |                      |
-| `ssh_port`                |  SSH port                                                   | ❌          | `22`                 |
-| `ssh_user`                |  SSH username                                               | ✅          |                      |
-| `ssh_key`                 |  SSH private key                                            | ✅          |                      |
-| `project_path`            |  Path on the server where files will be uploaded            | ✅          |                      |
-| `compose_files`           |  Comma-separated list of Compose files                      | ❌          | `docker-compose.yml` |
-| `stack_files`             |  Comma-separated list of Stack files                        | ❌          | `docker-stack.yml`   |
-| `extra_files`             |  Additional files to upload (like `.env` or `traefik.yml`)  | ❌          |                      |
-| `mode`                    |  Deployment mode (`compose` or `stack`)                     | ❌          | `compose`            |
-| `stack_name`              |  Swarm stack name (only used if `mode` is `stack`)          | ❌          |                      |
-| `docker_network`          |  Docker network name to ensure exists                       | ❌          |                      |
-| `docker_network_driver`   |  Network driver (`bridge`, `overlay`, `macvlan`, etc.)      | ❌          |                      |
-| `docker_prune`            |  Type of Docker prune to run after deployment               | ❌          |                      |
-| `registry_host`           |  Registry Authentication Host                               | ❌          |                      |
-| `registry_user`           |  Registry Authentication User                               | ❌          |                      |
-| `registry_pass`           |  Registry Authentication Pass                               | ❌          |                      |
+|  Input Parameter          |  Description                                                  | Required     | Default Value        |
+| ------------------------- | ------------------------------------------------------------- | :----------: | -------------------- |
+| `ssh_host`                |  Hostname or IP of the target server                          | ✅          |                      |
+| `ssh_port`                |  SSH port                                                     | ❌          | `22`                 |
+| `ssh_user`                |  SSH username                                                 | ✅          |                      |
+| `ssh_key`                 |  SSH private key                                              | ✅          |                      |
+| `project_path`            |  Path on the server where files will be uploaded              | ✅          |                      |
+| `deploy_file`             |  Path to the Docker Compose or Stack file used for deployment | ✅          | `docker-compose.yml` |
+| `extra_files`             |  Additional files to upload (like `.env` or `traefik.yml`)    | ❌          |                      |
+| `mode`                    |  Deployment mode (`compose` or `stack`)                       | ❌          | `compose`            |
+| `stack_name`              |  Swarm stack name (only used if `mode` is `stack`)            | ❌          |                      |
+| `docker_network`          |  Docker network name to ensure exists                         | ❌          |                      |
+| `docker_network_driver`   |  Network driver (`bridge`, `overlay`, `macvlan`, etc.)        | ❌          |                      |
+| `docker_prune`            |  Type of Docker prune to run after deployment                 | ❌          |                      |
+| `registry_host`           |  Registry Authentication Host                                 | ❌          |                      |
+| `registry_user`           |  Registry Authentication User                                 | ❌          |                      |
+| `registry_pass`           |  Registry Authentication Pass                                 | ❌          |                      |
 
 ## Supported Prune Types
 
@@ -63,6 +62,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Example 1: Deploy to Docker Swarm
       - name: Deploy to Docker Swarm
         uses: alcharra/docker-deploy-action@v1
         with:
@@ -70,7 +70,7 @@ jobs:
           ssh_user: ${{ secrets.SSH_USER }}
           ssh_key: ${{ secrets.SSH_KEY }}
           project_path: /opt/myapp
-          stack_files: docker-stack.yml
+          deploy_file: docker-stack.yml
           extra_files: .env,traefik.yml
           mode: stack
           stack_name: myapp
@@ -80,6 +80,24 @@ jobs:
           registry_host: ghcr.io
           registry_user: ${{ github.actor }}
           registry_pass: ${{ secrets.GITHUB_TOKEN }}
+
+      # Example 2: Deploy using Docker Compose
+      - name: Deploy using Docker Compose
+        uses: alcharra/docker-deploy-action@v1
+        with:
+          ssh_host: ${{ secrets.SSH_HOST }}
+          ssh_user: ${{ secrets.SSH_USER }}
+          ssh_key: ${{ secrets.SSH_KEY }}
+          project_path: /opt/myapp
+          deploy_file: docker-compose.yml
+          extra_files: .env,database.env,nginx.conf  
+          mode: compose
+          docker_network: myapp_network
+          docker_network_driver: bridge
+          docker_prune: system
+          registry_host: docker.io
+          registry_user: ${{ secrets.DOCKER_USERNAME }}
+          registry_pass: ${{ secrets.DOCKER_PASSWORD }}
 ```
 
 ## How It Works

--- a/README.md
+++ b/README.md
@@ -1,39 +1,120 @@
-# 🐳 Docker Deploy Action
+# 🐳 Docker Deploy Action  
 
-This GitHub Action deploys Docker Compose or Docker Swarm services over SSH. It uploads files to a remote server, checks they are present, creates a Docker network if required, deploys the services and optionally runs a Docker prune after deployment.
+A **production-ready** GitHub Action for deploying **Docker Compose** or **Docker Swarm** services over SSH.  
 
-## Features
+This action securely **uploads deployment files**, ensures the **target server is ready** and **automates network creation** if needed. It deploys services with **health checks, rollback support and optional cleanup** to keep your infrastructure stable.  
 
-- Upload Docker Compose or Stack files to a remote server over SSH
-- Automatically creates the target project folder if it does not exist (with correct ownership and permissions)
-- Supports uploading additional files like `.env`, `traefik.yml` or custom configs
-- Supports authenticated Docker registry login (for private images)
-- Creates Docker networks if required, with configurable driver
-- Deploys services using either Docker Compose or Docker Swarm (with support for `--with-registry-auth` in Swarm mode)
-- Verifies services are healthy after deployment
-- Optionally runs a Docker prune to free up unused resources
-- Provides clear logs for all steps (including file transfers, Docker network management and service verification)
-- Automatically cleans up temporary SSH key files
+## 🚀 Key Features of Docker Deploy Action  
+
+- **📂 Flexible & Seamless Deployment** – Deploy **Docker Compose** or **Docker Swarm** configurations **over SSH**, with support for different environments.  
+- **🛠️ Automatic Project Setup** – Creates the **target project directory** if it doesn't exist, ensuring **correct ownership & permissions**.  
+- **📦 Secure Environment Support** – Upload any **configuration or environment files** needed for your deployment.  
+- **🔑 Private Registry Authentication** – Supports **secure login** to private container registries (Docker Hub, GitHub Container Registry, etc.).  
+- **🌐 Intelligent Network Management** – Automatically **creates Docker networks** when required, with configurable **drivers**.  
+- **🩺 Built-in Service Health Checks** – Ensures services **start correctly** and remain **healthy after deployment**.  
+- **♻️ Automatic Rollback for Failed Deployments** –  
+  - **Swarm Mode**: Rolls back to the **previously working state** using `docker service update --rollback`.  
+  - **Compose Mode**: Restores the **last successful deployment file** if services fail to start.  
+- **🧹 Automatic Cleanup & Pruning** – Optionally run **Docker prune** to free up unused resources.  
+- **📜 Detailed Logs for Debugging** – Provides **clear, structured logs** for **every step**, including **file transfers, network management and verification**.  
+- **🛡️ Secure by Design** – Automatically **removes sensitive SSH keys** after deployment to **enhance security**.  
+
+---
+
+### ⚡ **Why Use This Action?**  
+🚀 **Fast & Easy:** Automate Docker deployments without manual SSH access.  
+📂 **Multi-File Support:** Upload multiple **configuration files** (e.g., `.env`, secrets, custom YAML).  
+🔄 **Resilient Deployments:** Automatic rollback if services fail to start.  
+🩺 **Health Checks Built-In:** Ensures services are **actually running** after deployment.  
+🔐 **Secure by Design:** Encrypted SSH keys, registry authentication and automatic cleanup.  
+🛠️ **Full Control:** Custom networks, registry logins and detailed logs.  
 
 ## Inputs
 
-|  Input Parameter          |  Description                                                  | Required     | Default Value        |
-| ------------------------- | ------------------------------------------------------------- | :----------: | -------------------- |
-| `ssh_host`                |  Hostname or IP of the target server                          | ✅          |                      |
-| `ssh_port`                |  SSH port                                                     | ❌          | `22`                 |
-| `ssh_user`                |  SSH username                                                 | ✅          |                      |
-| `ssh_key`                 |  SSH private key                                              | ✅          |                      |
-| `project_path`            |  Path on the server where files will be uploaded              | ✅          |                      |
-| `deploy_file`             |  Path to the Docker Compose or Stack file used for deployment | ✅          | `docker-compose.yml` |
-| `extra_files`             |  Additional files to upload (like `.env` or `traefik.yml`)    | ❌          |                      |
-| `mode`                    |  Deployment mode (`compose` or `stack`)                       | ❌          | `compose`            |
-| `stack_name`              |  Swarm stack name (only used if `mode` is `stack`)            | ❌          |                      |
-| `docker_network`          |  Docker network name to ensure exists                         | ❌          |                      |
-| `docker_network_driver`   |  Network driver (`bridge`, `overlay`, `macvlan`, etc.)        | ❌          |                      |
-| `docker_prune`            |  Type of Docker prune to run after deployment                 | ❌          |                      |
-| `registry_host`           |  Registry Authentication Host                                 | ❌          |                      |
-| `registry_user`           |  Registry Authentication User                                 | ❌          |                      |
-| `registry_pass`           |  Registry Authentication Pass                                 | ❌          |                      |
+|  Input Parameter            |  Description                                                               | Required     | Default Value        |
+| -------------------------   | -------------------------------------------------------------------------- | :----------: | -------------------- |
+| `ssh_host`                  |  Hostname or IP of the target server                                       | ✅          |                      |
+| `ssh_port`                  |  SSH port                                                                  | ❌          | `22`                 |
+| `ssh_user`                  |  SSH username                                                              | ✅          |                      |
+| `ssh_key`                   |  SSH private key                                                           | ✅          |                      |
+| `project_path`              |  Path on the server where files will be uploaded                           | ✅          |                      |
+| `deploy_file`               |  Path to the Docker Compose or Stack file used for deployment              | ✅          | `docker-compose.yml` |
+| `extra_files`               |  Additional files to upload (e.g., `.env`, config files)                   | ❌          |                      |
+| `mode`                      |  Deployment mode (`compose` or `stack`)                                    | ❌          | `compose`            |
+| `stack_name`                |  Swarm stack name (only used if `mode` is `stack`)                         | ❌          |                      |
+| `docker_network`            |  Docker network name to ensure exists                                      | ❌          |                      |
+| `docker_network_driver`     |  Network driver (`bridge`, `overlay`, `macvlan`, etc.)                     | ❌          | `bridge`             |
+| `docker_network_attachable` |  Allow standalone containers to attach to the Swarm network (`true/false`) | ❌          | `false`              |
+| `docker_prune`              |  Type of Docker prune to run after deployment                              | ❌          |                      |
+| `registry_host`             |  Registry Authentication Host                                              | ❌          |                      |
+| `registry_user`             |  Registry Authentication User                                              | ❌          |                      |
+| `registry_pass`             |  Registry Authentication Pass                                              | ❌          |                      |
+| `enable_rollback`           |  Enable automatic rollback if deployment fails (`true/false`)              | ❌          | `false`              |
+
+## 🌐 **Network Management in This Action**
+
+This action **ensures the required network exists** before deployment and automatically creates it if missing.  
+
+### **How It Works:**
+- If **the specified network exists**, it **verifies the driver** and continues deployment.  
+- If **the network is missing**, it is **created automatically** using the specified driver.  
+- If **Swarm Mode (`stack`)** is used with the `overlay` driver:
+  - The action **checks if Swarm mode is active**.
+  - If Swarm **is not active**, a **warning** is displayed since `overlay` requires Swarm for multi-node communication.
+- If the **network should be attachable** (`docker_network_attachable: true`):
+  - The `--attachable` flag is **added automatically**, allowing standalone containers to connect to the network.
+- If an **existing network has a different driver**, a **warning is displayed**.
+
+### **Network Scenarios:**
+✅ **A Network Will Be Created If:**
+- The specified network **does not exist**.
+- The deployment uses **a custom network** (`docker_network` is set).
+- The driver is **valid and supported**.
+
+⚠️ **Warnings Will Be Shown If:**
+- The **existing network driver differs** from the specified `docker_network_driver`.
+- **Swarm mode is inactive**, but an **overlay network** is requested.
+
+### **Example Usage:**
+```yaml
+docker_network: my_network
+docker_network_driver: overlay
+docker_network_attachable: true
+```
+
+- If `my_network` **does not exist**, it will be **created automatically**.  
+- If **Swarm mode is inactive**, a **warning** is displayed, but deployment continues.  
+- The network is created with `--attachable`, allowing non-Swarm containers to connect.  
+
+For more details on Docker networking, see the [Docker Documentation](https://docs.docker.com/network/).
+
+## 🔄 Rollback Behavior
+
+Rollback automatically **reverts deployments** if the new deployment **fails to start properly**.
+
+### **How It Works:**
+- If **Swarm Mode (`stack`)** is used:
+  - **Docker Swarm’s built-in rollback** is triggered using:  
+    ```sh
+    docker service update --rollback <service-name>
+    ```
+  - This reverts **all services in the stack** to their last working state.
+
+- If **Compose Mode (`compose`)** is used:
+  - A **backup of the previous deployment file** is created before deployment.
+  - If services fail to start, the backup is **restored automatically** and Compose is re-deployed.
+  - If rollback is successful, the backup is **removed** to avoid stale files.
+
+### **Rollback Scenarios:**
+✅ **Rollback Triggers If:**
+- Services fail **health checks**.
+- A container **immediately exits** after starting.
+- Docker reports an **error during service startup**.
+
+❌ **Rollback Will NOT Trigger If:**
+- The deployment succeeds, even if the application has **internal errors**.
+- A manually stopped service is detected.
+- The user **disables rollback** (`enable_rollback: false`).
 
 ## Supported Prune Types
 
@@ -64,7 +145,7 @@ jobs:
 
       # Example 1: Deploy to Docker Swarm
       - name: Deploy to Docker Swarm
-        uses: alcharra/docker-deploy-action@v1
+        uses: alcharra/docker-deploy-action@v2
         with:
           ssh_host: ${{ secrets.SSH_HOST }}
           ssh_user: ${{ secrets.SSH_USER }}
@@ -83,7 +164,7 @@ jobs:
 
       # Example 2: Deploy using Docker Compose
       - name: Deploy using Docker Compose
-        uses: alcharra/docker-deploy-action@v1
+        uses: alcharra/docker-deploy-action@v2
         with:
           ssh_host: ${{ secrets.SSH_HOST }}
           ssh_user: ${{ secrets.SSH_USER }}
@@ -99,19 +180,6 @@ jobs:
           registry_user: ${{ secrets.DOCKER_USERNAME }}
           registry_pass: ${{ secrets.DOCKER_PASSWORD }}
 ```
-
-## How It Works
-
-1. A temporary SSH key file is created for connecting to the target server
-2. The action checks if `project_path` exists on the remote server, creating it if necessary with proper ownership and permissions
-3. All specified files (`compose`, `stack` and `extra_files`) are uploaded to the remote project directory
-4. After upload, the action verifies that all files exist on the remote server
-5. If registry credentials are provided, the action logs into the container registry to support pulling private images
-6. The action ensures the specified Docker network exists, creating it if required
-7. The action deploys the services using either `docker-compose` or `docker stack deploy`, depending on the configured mode
-8. After deployment, the action verifies that all services are running correctly
-9. Optionally, the action runs a Docker prune (type can be configured)
-10. Finally, the temporary SSH key file is removed to ensure no sensitive files remain on disk
 
 ## Requirements on the Server
 

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,11 @@ inputs:
   docker_network_driver:
     description: "Driver for the Docker network (bridge, overlay, macvlan, etc.)"
     required: false
+    default: "bridge"
+  docker_network_attachable:
+    description: "Allow standalone containers to attach to the Swarm network (true/false)"
+    required: false
+    default: "false"
   docker_prune:
     description: "Optional prune type: system, volumes, networks, images, containers, none"
     required: false
@@ -55,6 +60,10 @@ inputs:
   registry_pass:
     description: "Registry Authentication Pass"
     required: true
+  enable_rollback:
+    description: "Enable automatic rollback if deployment fails (true/false)"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -75,6 +84,8 @@ runs:
         STACK_NAME: ${{ inputs.stack_name }}
         DOCKER_NETWORK: ${{ inputs.docker_network }}
         DOCKER_NETWORK_DRIVER: ${{ inputs.docker_network_driver }}
+        DOCKER_NETWORK_ATTACHABLE: ${{ inputs.docker_network_attachable }}
         REGISTRY_HOST: ${{ inputs.registry_host }}
         REGISTRY_USER: ${{ inputs.registry_user }}
         REGISTRY_PASS: ${{ inputs.registry_pass }}
+        ENABLE_ROLLBACK: ${{ inputs.enable_rollback }}

--- a/action.yml
+++ b/action.yml
@@ -22,14 +22,10 @@ inputs:
   project_path:
     description: "Remote directory on server where files should be uploaded"
     required: true
-  compose_files:
-    description: "Comma-separated list of files for Docker Compose (for standalone mode)"
-    required: false
+  deploy_file:
+    description: "Path to the Docker Compose or Stack file used for deployment"
+    required: true
     default: "docker-compose.yml"
-  stack_files:
-    description: "Comma-separated list of files for Docker Swarm (for stack mode)"
-    required: false
-    default: "docker-stack.yml"
   extra_files:
     description: "Additional files to upload (like .env, traefik.yml)"
     required: false
@@ -72,8 +68,7 @@ runs:
         SSH_USER: ${{ inputs.ssh_user }}
         SSH_KEY: ${{ inputs.ssh_key }}
         PROJECT_PATH: ${{ inputs.project_path }}
-        COMPOSE_FILES: ${{ inputs.compose_files }}
-        STACK_FILES: ${{ inputs.stack_files }}
+        DEPLOY_FILE: ${{ inputs.deploy_file }}
         EXTRA_FILES: ${{ inputs.extra_files }}
         DOCKER_PRUNE: ${{ inputs.docker_prune }}
         MODE: ${{ inputs.mode }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,193 +9,166 @@ DEPLOY_KEY_PATH=$(mktemp)
 echo "$SSH_KEY" > "$DEPLOY_KEY_PATH"
 chmod 600 "$DEPLOY_KEY_PATH"
 
-# Determine which files to upload based on mode
-if [ "$MODE" == "stack" ]; then
-    FILES="$STACK_FILES"
-else
-    FILES="$COMPOSE_FILES"
-fi
-
-# Build list of files to upload (main files + extra files)
-IFS=',' read -ra FILE_LIST <<< "$FILES"
-IFS=',' read -ra EXTRA_FILES_LIST <<< "$EXTRA_FILES"
-
-ALL_FILES=("${FILE_LIST[@]}" "${EXTRA_FILES_LIST[@]}")
-
-if [ ${#ALL_FILES[@]} -eq 0 ]; then
-    echo "❌ No files specified for upload"
-    exit 1
-fi
-
-# Upload all files in a single scp command
-for file in "${ALL_FILES[@]}"; do
-    if [ ! -f "$file" ]; then
-        echo "❌ Required file $file not found"
-        exit 1
-    fi
-done
-
 # Ensure project path exists
 echo "📂 Checking if project path exists on remote server: $PROJECT_PATH"
 
-ssh -i "$DEPLOY_KEY_PATH" -o StrictHostKeyChecking=no -p "$SSH_PORT" -T "$SSH_USER@$SSH_HOST" <<EOF
-if [ ! -d "$PROJECT_PATH" ]; then
-    echo '📁 Project path not found - creating it...'
-    sudo mkdir -p "$PROJECT_PATH"
-    sudo chown "$SSH_USER":"$SSH_USER" "$PROJECT_PATH"
-    sudo chmod 750 "$PROJECT_PATH"
-
-    # Explicitly check that it exists after creation
+ssh -i "$DEPLOY_KEY_PATH" -o StrictHostKeyChecking=no -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" bash -s <<EOF
     if [ ! -d "$PROJECT_PATH" ]; then
-        echo '❌ Failed to create project path!'
-        exit 1
-    fi
+        echo '📁 Project path not found - creating it...'
+        mkdir -p "$PROJECT_PATH"
+        chown "$SSH_USER":"$SSH_USER" "$PROJECT_PATH"
+        chmod 750 "$PROJECT_PATH"
 
-    echo '✅ Project path created and verified.'
-else
-    echo '✅ Project path already exists.'
-fi
+        # Verify that it exists after creation
+        if [ ! -d "$PROJECT_PATH" ]; then
+            echo '❌ Failed to create project path!'
+            exit 1
+        fi
+
+        echo '✅ Project path created and verified.'
+    else
+        echo '✅ Project path already exists.'
+    fi
 EOF
 
-# Upload all files
-echo "📂 Uploading files to $SSH_USER@$SSH_HOST:$PROJECT_PATH"
+# Verify the deploy file exists
+if [ ! -f "$DEPLOY_FILE" ]; then
+    echo "❌ Required file $DEPLOY_FILE not found"
+    exit 1
+fi
 
-scp -i "$DEPLOY_KEY_PATH" -o StrictHostKeyChecking=no -P "$SSH_PORT" "${ALL_FILES[@]}" "$SSH_USER@$SSH_HOST:$PROJECT_PATH/"
+# Prepare list of files to upload
+FILES_TO_UPLOAD=("$DEPLOY_FILE")
 
-echo "🔗 Connecting to $SSH_USER@$SSH_HOST to deploy..."
+# Process extra files but only if EXTRA_FILES is set
+if [[ -n "$EXTRA_FILES" ]]; then
+    IFS=',' read -ra EXTRA_FILES_LIST <<< "$EXTRA_FILES"
+
+    for file in "${EXTRA_FILES_LIST[@]}"; do
+        if [ ! -f "$file" ]; then
+            echo "❌ Extra file $file not found"
+            exit 1
+        fi
+        FILES_TO_UPLOAD+=("$file")
+    done
+fi
+
+# Convert array to string for SSH
+FILES_TO_UPLOAD_STR=$(printf "%s " "${FILES_TO_UPLOAD[@]}")
+
+# Upload all files in a single scp command
+echo "📂 Uploading files to $SSH_USER@$SSH_HOST:$PROJECT_PATH/"
+scp -i "$DEPLOY_KEY_PATH" -o StrictHostKeyChecking=no -P "$SSH_PORT" "${FILES_TO_UPLOAD[@]}" "$SSH_USER@$SSH_HOST:$PROJECT_PATH/"
 
 # Connect to remote server to deploy
-ssh -i "$DEPLOY_KEY_PATH" -o StrictHostKeyChecking=no -p "$SSH_PORT" -T "$SSH_USER@$SSH_HOST" <<EOF
-set -e
+echo "🔗 Connecting to $SSH_USER@$SSH_HOST to deploy..."
+ssh -i "$DEPLOY_KEY_PATH" -o StrictHostKeyChecking=no -p "$SSH_PORT" "$SSH_USER@$SSH_HOST" bash -s <<EOF
+    set -e
 
-echo "✅ Connected to $SSH_HOST"
+    echo "✅ Connected to $SSH_HOST"
 
-# Verify all uploaded files exist
-for file in "${ALL_FILES[@]}"; do
-    filename=\$(basename "\$file")
-    if [ ! -f "$PROJECT_PATH/\$filename" ]; then
-        echo "❌ Missing file after upload: \$filename"
-        exit 1
-    fi
-done
+    # Verify all uploaded files exist
+    for file in $FILES_TO_UPLOAD_STR; do
+        filename=$(basename "$file")
+        if ! ls "$PROJECT_PATH/$filename" >/dev/null 2>&1; then
+            echo "❌ Missing file after upload: $PROJECT_PATH/$filename"
+            exit 1
+        fi
+    done
 
-echo "✅ All files verified on server"
+    echo "✅ All files verified on server"
 
-# Create network if needed
-if [ -n "$DOCKER_NETWORK" ]; then
-    echo "🌐 Ensuring network $DOCKER_NETWORK exists"
+    # Create network if needed
+    if [ -n "$DOCKER_NETWORK" ]; then
+        echo "🌐 Ensuring network $DOCKER_NETWORK exists"
 
-    if ! docker network inspect "$DOCKER_NETWORK" > /dev/null 2>&1; then
-        if [ -z "$DOCKER_NETWORK_DRIVER" ]; then
-            if [ "$MODE" == "stack" ]; then
-                DOCKER_NETWORK_DRIVER="overlay"
+        if ! docker network inspect "$DOCKER_NETWORK" > /dev/null 2>&1; then
+            echo "🔧 Creating $DOCKER_NETWORK network with driver $DOCKER_NETWORK_DRIVER"
+
+            if [ "$MODE" == "stack" ] && [ "$DOCKER_NETWORK_DRIVER" == "overlay" ]; then
+                # Use --scope swarm only for overlay networks in Swarm mode
+                docker network create \
+                    --driver "$DOCKER_NETWORK_DRIVER" \
+                    --scope swarm \
+                    "$DOCKER_NETWORK"
             else
-                DOCKER_NETWORK_DRIVER="bridge"
+                docker network create \
+                    --driver "$DOCKER_NETWORK_DRIVER" \
+                    "$DOCKER_NETWORK"
             fi
-        fi
 
-        echo "🔧 Creating $DOCKER_NETWORK network with driver $DOCKER_NETWORK_DRIVER"
-
-        if [ "$MODE" == "stack" ]; then
-            docker network create \
-                --driver "$DOCKER_NETWORK_DRIVER" \
-                --scope swarm \
-                --attachable \
-                "$DOCKER_NETWORK"
+            # Verify network creation
+            if docker network inspect "$DOCKER_NETWORK" > /dev/null 2>&1; then
+                echo "✅ Network $DOCKER_NETWORK successfully created"
+            else
+                echo "❌ Network creation failed for $DOCKER_NETWORK!"
+                exit 1
+            fi
         else
-            docker network create \
-                --driver "$DOCKER_NETWORK_DRIVER" \
-                "$DOCKER_NETWORK"
+            echo "✅ Network $DOCKER_NETWORK already exists"
         fi
+    fi
 
-        if docker network inspect "$DOCKER_NETWORK" > /dev/null 2>&1; then
-            echo "✅ Network $DOCKER_NETWORK successfully created"
+    echo "📦 Changing directory to $PROJECT_PATH"
+    cd "$PROJECT_PATH" || { echo "❌ Failed to change directory"; exit 1; }
+
+    # Optional Registry Login
+    if [ -n "$REGISTRY_HOST" ] && [ -n "$REGISTRY_USER" ] && [ -n "$REGISTRY_PASS" ]; then
+        echo "🔑 Logging into container registry: $REGISTRY_HOST"
+        echo "$REGISTRY_PASS" | docker login "$REGISTRY_HOST" -u "$REGISTRY_USER" --password-stdin
+    else
+        echo "⏭️ Skipping container registry login - credentials not provided"
+    fi
+
+    # Deploy stack or compose services
+    if [ "$MODE" == "stack" ]; then
+        echo "⚓ Deploying stack $STACK_NAME using Docker Swarm"
+        docker stack deploy -c "$DEPLOY_FILE" "$STACK_NAME" --with-registry-auth --detach=false
+
+        echo "✅ Verifying services in stack $STACK_NAME"
+        docker service ls --filter "label=com.docker.stack.namespace=$STACK_NAME"
+        
+        # Verify stack services are running
+        if ! docker service ls --filter "label=com.docker.stack.namespace=$STACK_NAME" | grep -v REPLICAS | grep -q " 0/"; then
+            echo "✅ All services in stack $STACK_NAME are running correctly"
         else
-            echo "❌ Network creation failed for $DOCKER_NETWORK!"
+            echo "❌ One or more services failed to start in stack $STACK_NAME!"
+            docker service ls --filter "label=com.docker.stack.namespace=$STACK_NAME"
             exit 1
         fi
     else
-        echo "✅ Network $DOCKER_NETWORK already exists"
+        echo "🐳 Deploying using Docker Compose"
+
+        # Detect correct docker-compose command
+        DOCKER_COMPOSE_CMD=$(command -v docker-compose || command -v docker compose)
+
+        $DOCKER_COMPOSE_CMD pull && 
+        $DOCKER_COMPOSE_CMD down && 
+        $DOCKER_COMPOSE_CMD up -d
+
+        echo "✅ Verifying Compose services"
+
+        # Verify all compose services are running
+        if $DOCKER_COMPOSE_CMD ps | grep -E "Exit|Restarting|Dead"; then
+            echo "❌ One or more services failed to start!"
+            docker-compose ps
+            exit 1
+        else
+            echo "✅ All services are running"
+            docker-compose ps
+        fi
     fi
-fi
 
-echo "📦 Changing directory to $PROJECT_PATH"
-cd $PROJECT_PATH
-
-# Optional Registry Login
-if [ -n "$REGISTRY_HOST" ] && [ -n "$REGISTRY_USER" ] && [ -n "$REGISTRY_PASS" ]; then
-    echo "🔑 Logging into container registry: $REGISTRY_HOST"
-    echo "$REGISTRY_PASS" | docker login "$REGISTRY_HOST" -u "$REGISTRY_USER" --password-stdin
-else
-    echo "⏭️ Skipping container registry login - credentials not provided"
-fi
-
-# Deploy stack or compose services
-if [ "$MODE" == "stack" ]; then
-    echo "⚓ Deploying stack $STACK_NAME using Docker Swarm"
-    docker stack deploy -c ${FILES//,/ -c } $STACK_NAME --with-registry-auth --detach=false
-
-    echo "✅ Verifying services in stack $STACK_NAME"
-    docker service ls --filter "label=com.docker.stack.namespace=$STACK_NAME"
-    
-    # Verify stack services are running
-    if ! docker service ls --filter "label=com.docker.stack.namespace=$STACK_NAME" | grep -v REPLICAS | grep -q " 0/"; then
-        echo "✅ All services in stack $STACK_NAME are running correctly"
-    else
-        echo "❌ One or more services failed to start in stack $STACK_NAME!"
-        docker service ls --filter "label=com.docker.stack.namespace=$STACK_NAME"
-        exit 1
-    fi
-else
-    echo "🐳 Deploying using Docker Compose"
-    docker-compose pull
-    docker-compose down
-    docker-compose up -d
-
-    echo "✅ Verifying Compose services"
-
-    # Verify all compose services are running
-    if docker-compose ps | grep -E "Exit|Restarting|Dead"; then
-        echo "❌ One or more services failed to start!"
-        docker-compose ps
-        exit 1
-    else
-        echo "✅ All services are running"
-        docker-compose ps
-    fi
-fi
-
-# Run optional docker prune (type: system, volumes, networks, images, containers, none)
-case "$DOCKER_PRUNE" in
-    system)
-        echo "🧹 Running full system prune (images, containers, volumes, networks)"
-        docker system prune -f
-        ;;
-    volumes)
-        echo "📦 Running volume prune (removing unused volumes)"
-        docker volume prune -f
-        ;;
-    networks)
-        echo "🌐 Running network prune (removing unused networks)"
-        docker network prune -f
-        ;;
-    images)
-        echo "🖼️ Running image prune (removing unused images)"
-        docker image prune -f
-        ;;
-    containers)
-        echo "📦 Running container prune (removing stopped containers)"
-        docker container prune -f
-        ;;
-    none|"")
-        echo "⏭️ Skipping docker prune"
-        ;;
-    *)
-        echo "❌ Invalid prune type: $DOCKER_PRUNE"
-        exit 1
-        ;;
-esac
-
+    # Run optional docker prune
+    case "$DOCKER_PRUNE" in
+        system) echo "🧹 Running full system prune"; docker system prune -f ;;
+        volumes) echo "📦 Running volume prune"; docker volume prune -f ;;
+        networks) echo "🌐 Running network prune"; docker network prune -f ;;
+        images) echo "🖼️ Running image prune"; docker image prune -f ;;
+        containers) echo "📦 Running container prune"; docker container prune -f ;;
+        none|"") echo "⏭️ Skipping docker prune" ;;
+        *) echo "❌ Invalid prune type: $DOCKER_PRUNE"; exit 1 ;;
+    esac
 EOF
 
 # Cleanup SSH key


### PR DESCRIPTION
… and fix docker network handling


### 🚀 Summary of Changes
- **Replaced `stack_file` and `compose_file` with a single `deploy_file`**
  - `deploy_file` is now a **single file path** instead of a comma-separated list.
  - **Extra files should now be passed using `extra_files` instead**.
- Made `deploy_file` a required input for clarity
- Fixed SCP upload issue ensuring correct destination
- Improved `docker-compose` detection (now detects `docker compose` and `docker-compose`)
- Fixed Docker network creation:
  - `--scope swarm` is now **only used** for `overlay` networks
  - Other network types no longer receive `--scope swarm`
- **Removed `sudo` requirement** for creating the `project_path`
  - Now creates the directory **as the SSH user** instead of requiring `sudo`
  - Prevents permission issues when deploying as a non-root user
- **Used `bash -s` for SSH execution**
  - Prevents `MOTD` messages from interfering with script execution
  - Ensures a clean SSH session when running commands
- Updated example workflows in README
  - Added separate examples for `docker-compose` and `docker stack`
  - Updated registry handling (`ghcr.io` for Swarm, `docker.io` for Compose)
- Added better error handling for missing files and extra files
- Added `docker_network_attachable` input to enable `--attachable` for overlay networks
- Ensured `--scope swarm` is only used when Swarm mode is active
- Added warnings if Swarm mode is inactive when using an overlay network
- Improved network verification to check for existing networks with mismatched drivers
- Updated documentation to clarify network management and attachable networks
