### PR TITLE
fix: use basename of deploy_file to prevent stack deploy path issues

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -22,8 +22,8 @@ jobs:
           ssh_user: ${{ secrets.TEST_SSH_USER }}
           ssh_key: ${{ secrets.TEST_SSH_KEY }}
           project_path: /home/${{ secrets.TEST_SSH_USER }}/test/compose
-          deploy_file: tests/compose/docker-compose.yml
-          extra_files: tests/compose/.env
+          deploy_file: ./tests/compose/docker-compose.yml
+          extra_files: ./tests/compose/.env
           mode: compose
           docker_network: test_network_compose
           docker_network_driver: bridge
@@ -45,8 +45,8 @@ jobs:
           ssh_user: ${{ secrets.TEST_SSH_USER }}
           ssh_key: ${{ secrets.TEST_SSH_KEY }}
           project_path: /home/${{ secrets.TEST_SSH_USER }}/test/stack
-          deploy_file: tests/stack/docker-stack.yml
-          extra_files: tests/stack/redis.conf,tests/stack/nginx.conf
+          deploy_file: ./tests/stack/docker-stack.yml
+          extra_files: ./tests/stack/redis.conf,./tests/stack/nginx.conf
           mode: stack
           stack_name: test_stack
           docker_network: test_network_stack

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,0 +1,55 @@
+name: Deploy Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  deploy-compose:
+    name: Deploy Test (Compose)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Test Docker Deploy Action - Compose
+        uses: alcharra/docker-deploy-action@v2
+        with:
+          ssh_host: ${{ secrets.TEST_SSH_HOST }}
+          ssh_user: ${{ secrets.TEST_SSH_USER }}
+          ssh_key: ${{ secrets.TEST_SSH_KEY }}
+          project_path: /home/${{ secrets.TEST_SSH_USER }}/test/compose
+          deploy_file: tests/compose/docker-compose.yml
+          extra_files: tests/compose/.env
+          mode: compose
+          docker_network: test_network_compose
+          docker_network_driver: bridge
+          docker_prune: system
+          enable_rollback: true
+
+  deploy-stack:
+    name: Deploy Test (Stack)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Test Docker Deploy Action - Stack
+        uses: alcharra/docker-deploy-action@v2
+        with:
+          ssh_host: ${{ secrets.TEST_SSH_HOST }}
+          ssh_user: ${{ secrets.TEST_SSH_USER }}
+          ssh_key: ${{ secrets.TEST_SSH_KEY }}
+          project_path: /home/${{ secrets.TEST_SSH_USER }}/test/stack
+          deploy_file: tests/stack/docker-stack.yml
+          extra_files: tests/stack/redis.conf,tests/stack/nginx.conf
+          mode: stack
+          stack_name: test_stack
+          docker_network: test_network_stack
+          docker_network_driver: overlay
+          docker_prune: system
+          enable_rollback: true

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,10 +2,12 @@ name: ShellCheck
 
 on:
   push:
+    branches: [main]
     paths:
       - '**.sh'
       - '.github/workflows/shellcheck.yml'
   pull_request:
+    branches: [main]
     paths:
       - '**.sh'
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,24 @@
+name: ShellCheck
+
+on:
+  push:
+    paths:
+      - '**.sh'
+      - '.github/workflows/shellcheck.yml'
+  pull_request:
+    paths:
+      - '**.sh'
+
+jobs:
+  shellcheck:
+    name: Run ShellCheck
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          severity: style

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@2.0.0
         with:
-          severity: style
+          severity: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+# Logs and temp files
+*.log
+*.tmp
+*.bak
+*.swp
+*.swo
+*.swn
+*.orig
+*~
+
+# SSH keys and sensitive files
+*.pem
+*.pub
+*.key
+*.crt
+*.env
+!.env.example
+
+# Docker-related overrides and folders
+docker-compose.override.yml
+docker-compose.*.yml
+.env.docker
+.docker/
+
+# OS-generated files
+.DS_Store
+Thumbs.db
+
+# GitHub Actions temp/artifact files
+__generated__/
+.github/*.bak
+.github/*~
+.github/workflows/*.bak
+
+# IDE/editor configs
+.vscode/
+.idea/
+*.code-workspace
+
+# Python cache
+__pycache__/
+*.py[cod]
+
+# Node dependencies or builds
+node_modules/
+dist/
+npm-debug.log*
+
+# Backup or archive files
+*.tar
+*.gz
+*.zip
+
+# ShellCheck backup
+*.shellcheck
+
+# Local deployment artifacts
+deploy-key
+deploy.sh.backup

--- a/README.md
+++ b/README.md
@@ -1,33 +1,34 @@
-# 🐳 Docker Deploy Action  
+# 🐳 Docker Deploy Action
+
+[![Deploy Test](https://github.com/alcharra/docker-deploy-action/actions/workflows/deploy-test.yml/badge.svg)](https://github.com/alcharra/docker-deploy-action/actions/workflows/deploy-test.yml)
+[![GitHub tag](https://img.shields.io/github/tag/alcharra/docker-deploy-action.svg)](https://github.com/alcharra/docker-deploy-action-go/releases)
+[![ShellCheck](https://github.com/alcharra/docker-deploy-action/actions/workflows/shellcheck.yml/badge.svg)](https://github.com/alcharra/docker-deploy-action/actions/workflows/shellcheck.yml)
 
 A **production-ready** GitHub Action for deploying **Docker Compose** or **Docker Swarm** services over SSH.  
 
-This action securely **uploads deployment files**, ensures the **target server is ready** and **automates network creation** if needed. It deploys services with **health checks, rollback support and optional cleanup** to keep your infrastructure stable.  
+This action securely **uploads deployment files**, ensures the **target server is ready** and **automates network creation** if needed. It deploys services with **health checks, rollback support and optional cleanup** to keep your infrastructure stable.
 
-## 🚀 Key Features of Docker Deploy Action  
+> ℹ️ **Notice:** A faster, lightweight alternative built with Go is now available!  
+> Check out [docker-deploy-action-go](https://github.com/alcharra/docker-deploy-action-go) – same features, better performance 🚀  
+> 🛠️ **This action will continue to be actively maintained and updated.**
 
-- **📂 Flexible & Seamless Deployment** – Deploy **Docker Compose** or **Docker Swarm** configurations **over SSH**, with support for different environments.  
-- **🛠️ Automatic Project Setup** – Creates the **target project directory** if it doesn't exist, ensuring **correct ownership & permissions**.  
-- **📦 Secure Environment Support** – Upload any **configuration or environment files** needed for your deployment.  
-- **🔑 Private Registry Authentication** – Supports **secure login** to private container registries (Docker Hub, GitHub Container Registry, etc.).  
-- **🌐 Intelligent Network Management** – Automatically **creates Docker networks** when required, with configurable **drivers**.  
-- **🩺 Built-in Service Health Checks** – Ensures services **start correctly** and remain **healthy after deployment**.  
-- **♻️ Automatic Rollback for Failed Deployments** –  
-  - **Swarm Mode**: Rolls back to the **previously working state** using `docker service update --rollback`.  
-  - **Compose Mode**: Restores the **last successful deployment file** if services fail to start.  
-- **🧹 Automatic Cleanup & Pruning** – Optionally run **Docker prune** to free up unused resources.  
-- **📜 Detailed Logs for Debugging** – Provides **clear, structured logs** for **every step**, including **file transfers, network management and verification**.  
-- **🛡️ Secure by Design** – Automatically **removes sensitive SSH keys** after deployment to **enhance security**.  
+## What This Action Brings You
 
----
+This GitHub Action makes your Docker deployments smooth, secure and reliable — whether you’re using Docker Compose or Swarm. Here's what you get out of the box:
 
-### ⚡ **Why Use This Action?**  
-🚀 **Fast & Easy:** Automate Docker deployments without manual SSH access.  
-📂 **Multi-File Support:** Upload multiple **configuration files** (e.g., `.env`, secrets, custom YAML).  
-🔄 **Resilient Deployments:** Automatic rollback if services fail to start.  
-🩺 **Health Checks Built-In:** Ensures services are **actually running** after deployment.  
-🔐 **Secure by Design:** Encrypted SSH keys, registry authentication and automatic cleanup.  
-🛠️ **Full Control:** Custom networks, registry logins and detailed logs.  
+- **📂 Flexible Deployments:** Deploy Docker Compose or Swarm stacks seamlessly over SSH to any Linux server.
+- **🛠️ Smart Setup:** Automatically creates the target project directory with the correct permissions and ownership.
+- **📦 Full Config Support:** Upload multiple config and environment files (`.env`, secrets, YAML, etc.) effortlessly.
+- **🔑 Private Registry Access:** Supports secure login to private registries like Docker Hub and GHCR.
+- **🌐 Network Intelligence:** Ensures required Docker networks exist or creates them automatically with your chosen driver.
+- **🩺 Health-First Deployments:** Built-in health checks confirm services are running and stable after deployment.
+- **♻️ Auto-Rollback on Failures:**  
+  - **Swarm:** Uses Docker's native `--rollback` feature.  
+  - **Compose:** Restores the last known working deployment file.
+- **🧹 Optional Cleanup:** Reclaim disk space with Docker prune—configurable by type.
+- **📜 Transparent Logs:** Get structured logs for every step — from file transfers to health checks.
+- **🛡️ Built-In Security:** SSH keys are securely handled and wiped after deployment to keep your infrastructure safe.
+- **🚀 Fast Automation:** No need for manual SSH commands — just push to GitHub and deploy!
 
 ## Inputs
 
@@ -51,79 +52,74 @@ This action securely **uploads deployment files**, ensures the **target server i
 | `registry_pass`             |  Registry Authentication Pass                                              | ❌          |                      |
 | `enable_rollback`           |  Enable automatic rollback if deployment fails (`true/false`)              | ❌          | `false`              |
 
-## 🌐 **Network Management in This Action**
+## Supported Prune Types
 
-This action **ensures the required network exists** before deployment and automatically creates it if missing.  
+- `none` – No pruning (default)
+- `system` – Remove unused images, containers, volumes and networks
+- `volumes` – Remove unused volumes
+- `networks` – Remove unused networks
+- `images` – Remove unused images
+- `containers` – Remove stopped containers
 
-### **How It Works:**
-- If **the specified network exists**, it **verifies the driver** and continues deployment.  
-- If **the network is missing**, it is **created automatically** using the specified driver.  
-- If **Swarm Mode (`stack`)** is used with the `overlay` driver:
-  - The action **checks if Swarm mode is active**.
-  - If Swarm **is not active**, a **warning** is displayed since `overlay` requires Swarm for multi-node communication.
-- If the **network should be attachable** (`docker_network_attachable: true`):
-  - The `--attachable` flag is **added automatically**, allowing standalone containers to connect to the network.
-- If an **existing network has a different driver**, a **warning is displayed**.
+## Network Management
 
-### **Network Scenarios:**
-✅ **A Network Will Be Created If:**
-- The specified network **does not exist**.
-- The deployment uses **a custom network** (`docker_network` is set).
-- The driver is **valid and supported**.
+This action ensures the required Docker network exists before deploying. If it is missing, it will be created automatically using the specified driver.
 
-⚠️ **Warnings Will Be Shown If:**
-- The **existing network driver differs** from the specified `docker_network_driver`.
-- **Swarm mode is inactive**, but an **overlay network** is requested.
+### How it works
 
-### **Example Usage:**
+- If the network already exists, its driver is verified.
+- If the network does not exist, it is created using the provided driver.
+- If `docker_network_attachable` is set to `true`, the network is created with the `--attachable` flag.
+- In `stack` mode with the `overlay` driver:
+  - Swarm mode must be active on the target server.
+  - A warning is displayed if Swarm is not active.
+- If the existing network uses a different driver than specified, a warning is displayed.
+
+### Network scenarios
+
+A network will be created if:
+- The specified network does not exist.
+- A custom network is defined via `docker_network`.
+- The provided driver is valid and supported.
+
+Warnings will be displayed if:
+- The existing network's driver does not match the one specified.
+- Swarm mode is inactive but `overlay` is requested in `stack` mode.
+
+### Example usage
+
 ```yaml
 docker_network: my_network
 docker_network_driver: overlay
 docker_network_attachable: true
 ```
 
-- If `my_network` **does not exist**, it will be **created automatically**.  
-- If **Swarm mode is inactive**, a **warning** is displayed, but deployment continues.  
-- The network is created with `--attachable`, allowing non-Swarm containers to connect.  
+## Rollback Behaviour
 
-For more details on Docker networking, see the [Docker Documentation](https://docs.docker.com/network/).
+This action supports automatic rollback if a deployment fails to start correctly.
 
-## 🔄 Rollback Behavior
+### How it works
 
-Rollback automatically **reverts deployments** if the new deployment **fails to start properly**.
+- In `stack` mode:
+  - Docker Swarm’s built-in rollback is used.
+  - The command `docker service update --rollback <service-name>` is run to revert services in the stack to the last working state.
 
-### **How It Works:**
-- If **Swarm Mode (`stack`)** is used:
-  - **Docker Swarm’s built-in rollback** is triggered using:  
-    ```sh
-    docker service update --rollback <service-name>
-    ```
-  - This reverts **all services in the stack** to their last working state.
+- In `compose` mode:
+  - A backup of the current deployment file is created before deployment.
+  - If services fail to start, the backup is restored and Compose is re-deployed.
+  - If rollback is successful, the backup file is removed to avoid stale data.
 
-- If **Compose Mode (`compose`)** is used:
-  - A **backup of the previous deployment file** is created before deployment.
-  - If services fail to start, the backup is **restored automatically** and Compose is re-deployed.
-  - If rollback is successful, the backup is **removed** to avoid stale files.
+### Rollback triggers
 
-### **Rollback Scenarios:**
-✅ **Rollback Triggers If:**
-- Services fail **health checks**.
-- A container **immediately exits** after starting.
-- Docker reports an **error during service startup**.
+Rollback will occur if:
+- Services fail health checks.
+- Containers immediately exit after starting.
+- Docker returns an error during service startup.
 
-❌ **Rollback Will NOT Trigger If:**
-- The deployment succeeds, even if the application has **internal errors**.
-- A manually stopped service is detected.
-- The user **disables rollback** (`enable_rollback: false`).
-
-## Supported Prune Types
-
-- `none`: No pruning (default)
-- `system`: Remove unused images, containers, volumes and networks
-- `volumes`: Remove unused volumes
-- `networks`: Remove unused networks
-- `images`: Remove unused images
-- `containers`: Remove stopped containers
+Rollback will not occur if:
+- The deployment succeeds but the application has internal errors.
+- A service is manually stopped by the user.
+- Rollback is disabled via `enable_rollback: false`.
 
 ## Example Workflow
 
@@ -190,7 +186,7 @@ jobs:
 
 ## Important Notes
 
-- This action is designed for Linux servers (Debian, Ubuntu, etc.)
+- This action is designed for Linux servers (Debian, Ubuntu, Alpine, CentOS)
 - The SSH user must have permissions to write files and run Docker commands
 - If the `project_path` does not exist, it will be created with permissions `750` and owned by the provided SSH user
 - If using Swarm mode, the target machine must be a Swarm manager
@@ -200,6 +196,7 @@ jobs:
 - [Docker Compose Documentation](https://docs.docker.com/compose/)
 - [Docker Swarm Documentation](https://docs.docker.com/engine/swarm/)
 - [Docker Prune Documentation](https://docs.docker.com/config/pruning/)
+- [Docker Documentation](https://docs.docker.com/network/)
 
 ## Tips for Maintainers
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -177,7 +177,8 @@ ssh -i "$DEPLOY_KEY_PATH" -o StrictHostKeyChecking=no -p "$SSH_PORT" "$SSH_USER@
         fi
 
         echo "⚓ Deploying stack $STACK_NAME using Docker Swarm"
-        docker stack deploy -c "$DEPLOY_FILE" "$STACK_NAME" --with-registry-auth --detach=false
+        STACK_FILE_NAME=\$(basename "$DEPLOY_FILE")
+        docker stack deploy -c "\$STACK_FILE_NAME" "$STACK_NAME" --with-registry-auth --detach=false
 
         # Verify stack services are running
         echo "✅ Verifying services in stack $STACK_NAME"
@@ -241,17 +242,15 @@ ssh -i "$DEPLOY_KEY_PATH" -o StrictHostKeyChecking=no -p "$SSH_PORT" "$SSH_USER@
                 else
                     echo "⚠️ No backup found! Rollback not possible."
                 fi
+
+                if ls "$PROJECT_PATH/${DEPLOY_FILE}.backup" >/dev/null 2>&1; then
+                    rm -f "$PROJECT_PATH/${DEPLOY_FILE}.backup"
+                    echo "🧹 Removed backup file after successful deployment."
+                fi
             fi
             exit 1
         else
             echo "✅ All services are running"
-        fi
-        # Cleanup backup file after a successful deployment
-        if [ "$ENABLE_ROLLBACK" == "true" ]; then
-            if ls "$PROJECT_PATH/${DEPLOY_FILE}.backup" >/dev/null 2>&1; then
-                rm -f "$PROJECT_PATH/${DEPLOY_FILE}.backup"
-                echo "🧹 Removed backup file after successful deployment."
-            fi
         fi
     fi
 

--- a/tests/compose/.env
+++ b/tests/compose/.env
@@ -1,0 +1,7 @@
+NGINX_HOST=localhost
+NGINX_PORT=80
+
+MYSQL_ROOT_PASSWORD=root
+MYSQL_DATABASE=test_db
+MYSQL_USER=test_user
+MYSQL_PASSWORD=test_password

--- a/tests/compose/docker-compose.yml
+++ b/tests/compose/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  app:
+    image: nginx:latest
+    container_name: test_nginx
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+    networks:
+      - test_network_compose
+    environment:
+      - NGINX_HOST=${NGINX_HOST}
+      - NGINX_PORT=${NGINX_PORT}
+
+  db:
+    image: mysql:latest
+    container_name: test_mysql
+    restart: unless-stopped
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - test_network_compose
+
+networks:
+  test_network_compose:
+    driver: bridge
+
+volumes:
+  mysql_data:

--- a/tests/stack/docker-stack.yml
+++ b/tests/stack/docker-stack.yml
@@ -1,0 +1,47 @@
+services:
+  web:
+    image: nginx:latest
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+    deploy:
+      replicas: 2
+      restart_policy:
+        condition: on-failure
+    ports:
+      - "8080:80"
+    networks:
+      - test_network_stack
+
+  db:
+    image: mysql:latest
+    environment:
+      MYSQL_ROOT_PASSWORD: example
+      MYSQL_DATABASE: app_db
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    volumes:
+      - db_data:/var/lib/mysql
+    deploy:
+      placement:
+        constraints: [node.role == manager]
+    networks:
+      - test_network_stack
+
+  redis:
+    image: redis:latest
+    volumes:
+      - ./redis.conf:/usr/local/etc/redis/redis.conf:ro
+    command: ["redis-server", "/usr/local/etc/redis/redis.conf"]
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+    networks:
+      - test_network_stack
+
+volumes:
+  db_data:
+
+networks:
+  test_network_stack:
+    driver: overlay

--- a/tests/stack/nginx.conf
+++ b/tests/stack/nginx.conf
@@ -1,0 +1,32 @@
+# Minimal NGINX Config for Docker Test
+
+user  nginx;
+worker_processes  auto;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    server {
+        listen 80;
+
+        server_name localhost;
+
+        location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+
+        error_page 404 /404.html;
+        location = /404.html {
+            internal;
+        }
+    }
+}

--- a/tests/stack/redis.conf
+++ b/tests/stack/redis.conf
@@ -1,0 +1,27 @@
+# Redis Configuration for Test Stack
+
+# Enable protected mode
+protected-mode yes
+
+# Set a password
+requirepass testpassword
+
+# Memory management
+maxmemory 100mb
+maxmemory-policy allkeys-lru
+
+# Persistence settings
+save 900 1
+save 300 10
+save 60 10000
+
+# Append only file settings
+appendonly yes
+appendfsync everysec
+
+# Logging
+loglevel notice
+logfile ""
+
+# Disable daemonization
+daemonize no


### PR DESCRIPTION
### 🚀 Summary of Changes

- Fixed a bug where `docker stack deploy` failed due to using the full repo-relative `deploy_file` path instead of just the filename.  
  - This caused deployment to fail on the remote server because only the file (not its directory structure) is uploaded.  
  - Now, the script uses `basename` to extract the filename before passing it to `docker stack deploy`.  
- Updated the README to improve clarity, structure and overall readability.  
- Added shell test workflow (`ShellCheck`) to ensure all Bash scripts are statically analysed for issues.  
- Added deploy test workflow for both Docker Compose and Swarm stack modes to validate action behavior end-to-end.
