### PR TITLE
feat: add support for targeted service restarts in Compose mode

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ inputs:
     required: true
     default: "docker-compose.yml"
   extra_files:
-    description: "A list of additional files to upload (e.g. .env, config.yml)."
+    description: "Comma-separated list of additional files to upload (e.g. .env, config.yml)."
     required: false
   mode:
     description: "The deployment mode to use (e.g. 'compose' or 'stack')."
@@ -53,6 +53,17 @@ inputs:
     description: "Whether to pull the latest images before bringing up services with Docker Compose (true/false)."
     required: false
     default: "true"
+  compose_build:
+    description: "Whether to build images before starting services with Docker Compose (true/false)."
+    required: false
+    default: "false"
+  compose_no_deps:
+    description: "Whether to skip starting linked services (dependencies) with Docker Compose (true/false)."
+    required: false
+    default: "false"
+  compose_target_services:
+    description: "Comma-separated list of services to restart (e.g. web,db) - Restarts all if unset."
+    required: false
   docker_network:
     description: "The name of the network to be used for deployment (created if it does not exist)."
     required: false
@@ -104,6 +115,9 @@ runs:
         MODE: ${{ inputs.mode }}
         STACK_NAME: ${{ inputs.stack_name }}
         COMPOSE_PULL: ${{ inputs.compose_pull }}
+        COMPOSE_BUILD: ${{ inputs.compose_build }}
+        COMPOSE_NO_DEPS: ${{ inputs.compose_no_deps }}
+        COMPOSE_TARGET_SERVICES: ${{ inputs.compose_target_services }}
         DOCKER_NETWORK: ${{ inputs.docker_network }}
         DOCKER_NETWORK_DRIVER: ${{ inputs.docker_network_driver }}
         DOCKER_NETWORK_ATTACHABLE: ${{ inputs.docker_network_attachable }}


### PR DESCRIPTION
### 🚀 Summary of Changes

- Added support for more granular control over Docker Compose deployments:
  - `compose_build`: optionally build images before starting services
  - `compose_no_deps`: optionally skip starting linked services
  - `compose_target_services`: specify a list of services to restart instead of restarting all
- These inputs allow faster, more controlled deployments for projects where full service restarts aren't always needed.
- Updated input documentation and examples to reflect the new options.
