### PR TITLE
feat: support environment variables via ENV_VARS input

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,8 +223,14 @@ jobs:
           deploy_file: docker-compose.yml
           mode: compose
 
+          # Environment Variables 
+          env_vars: |
+            DB_HOST=localhost
+            DB_USER=myuser
+            DB_PASS=${{ secrets.DB_PASS }}
+
           # Additional Files
-          extra_files: .env,database.env,nginx.conf              # Upload environment and config files
+          extra_files: database.env,nginx.conf                  # Upload environment and config files
 
           # Compose Behaviour
           compose_pull: true                                     # Pull latest images before up

--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,9 @@ inputs:
     description: "Whether to enable automatic rollback if the deployment fails (true/false)."
     required: false
     default: "false"
+  env_vars:
+    description: "Environment variables to write to a .env file and upload to the server."
+    required: false
 
 runs:
   using: "composite"
@@ -126,3 +129,4 @@ runs:
         REGISTRY_USER: ${{ inputs.registry_user }}
         REGISTRY_PASS: ${{ inputs.registry_pass }}
         ENABLE_ROLLBACK: ${{ inputs.enable_rollback }}
+        ENV_VARS: ${{ inputs.env_vars }}

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -15,6 +15,12 @@ if [[ -n "$KNOWN_HOSTS_PATH" && -f "$KNOWN_HOSTS_PATH" ]]; then
     echo "🗑️ Removed temporary known_hosts file"
 fi
 
+# Remove .env file
+if [[ -f ".env" ]]; then
+    rm -f .env
+    echo "🗑️ Removed temporary .env file"
+fi
+
 # Kill ssh-agent if running
 if [[ -n "$SSH_AGENT_PID" ]]; then
     kill "$SSH_AGENT_PID" >/dev/null 2>&1 || true

--- a/scripts/deploy_compose.sh
+++ b/scripts/deploy_compose.sh
@@ -64,6 +64,8 @@ ssh -i "$DEPLOY_KEY_PATH" \
     # Verify services
     echo "🔍 Verifying services..."
 
+    COMPOSE_FILE_NAME=\$(basename "$DEPLOY_FILE") 
+
     if \$COMPOSE_CMD ps | grep -E "Exit|Restarting|Dead" >/dev/null; then
         echo "❌ One or more services failed to start"
         \$COMPOSE_CMD ps
@@ -72,17 +74,15 @@ ssh -i "$DEPLOY_KEY_PATH" \
         if [[ "$ENABLE_ROLLBACK" == "true" ]]; then
             echo "🔄 Attempting rollback..."
 
-            if [[ -f "${PROJECT_PATH}/${DEPLOY_FILE}.backup" ]]; then
+            if [[ -f "\$COMPOSE_FILE_NAME.backup" ]]; then
                 echo "♻️ Restoring backup deployment file"
-                mv "${PROJECT_PATH}/${DEPLOY_FILE}.backup" "${PROJECT_PATH}/${DEPLOY_FILE}"
+                mv "\$COMPOSE_FILE_NAME.backup" "\$COMPOSE_FILE_NAME"
 
                 echo "♻️ Re-deploying previous version"
                 \$COMPOSE_CMD down
                 \$COMPOSE_CMD up -d
 
                 echo "✅ Rollback successful"
-                # Clean up backup file
-                rm -f "${PROJECT_PATH}/${DEPLOY_FILE}.backup"
             else
                 echo "⚠️ No backup file found, rollback skipped"
             fi
@@ -92,4 +92,7 @@ ssh -i "$DEPLOY_KEY_PATH" \
     else
         echo "✅ All services are running"
     fi
+
+    # Clean up backup file
+    rm -f "\$COMPOSE_FILE_NAME.backup"
 EOF

--- a/scripts/deploy_stack.sh
+++ b/scripts/deploy_stack.sh
@@ -31,9 +31,9 @@ ssh -i "$DEPLOY_KEY_PATH" \
     # Change to project directory
     cd "$PROJECT_PATH"
 
+    echo "⚓ Deploying stack: $STACK_NAME using file: \$STACK_FILE_NAME"
     STACK_FILE_NAME=\$(basename "$DEPLOY_FILE")
 
-    echo "⚓ Deploying stack: $STACK_NAME using file: \$STACK_FILE_NAME"
     docker stack deploy -c "\$STACK_FILE_NAME" "$STACK_NAME" --with-registry-auth --detach=false
 
     echo "🔍 Verifying services in stack: $STACK_NAME"

--- a/scripts/prepare_remote_target.sh
+++ b/scripts/prepare_remote_target.sh
@@ -34,11 +34,13 @@ ssh -i "$DEPLOY_KEY_PATH" \
     if [ "$ENABLE_ROLLBACK" == "true" ] && [ "$MODE" == "compose" ]; then
         echo "🔄 Creating a backup of the current deployment file (if exists)"
         
-        if ls "$PROJECT_PATH/$DEPLOY_FILE" >/dev/null 2>&1; then
-            cp "$PROJECT_PATH/$DEPLOY_FILE" "$PROJECT_PATH/${DEPLOY_FILE}.backup"
+        COMPOSE_FILE_NAME=\$(basename "$DEPLOY_FILE")
 
-            if ls "$PROJECT_PATH/${DEPLOY_FILE}.backup" >/dev/null 2>&1; then
-                echo "✅ Backup created: ${DEPLOY_FILE}.backup"
+        if ls "$PROJECT_PATH/\$COMPOSE_FILE_NAME" >/dev/null 2>&1; then
+            cp "$PROJECT_PATH/\$COMPOSE_FILE_NAME" "$PROJECT_PATH/\$COMPOSE_FILE_NAME.backup"
+
+            if ls "$PROJECT_PATH/\$COMPOSE_FILE_NAME.backup" >/dev/null 2>&1; then
+                echo "✅ Backup created: \$COMPOSE_FILE_NAME.backup"
             else
                 echo "❌ Backup creation failed!"
                 exit 1

--- a/scripts/upload_and_verify_files.sh
+++ b/scripts/upload_and_verify_files.sh
@@ -23,6 +23,13 @@ if [[ -n "$EXTRA_FILES" ]]; then
     done
 fi
 
+# Export INPUT_ENV_VARS to .env file and upload if provided
+if [[ -n "${ENV_VARS}" ]]; then
+    echo "🌿 Creating .env file with environment variables..."
+    echo "${ENV_VARS}" > .env
+    FILES_TO_UPLOAD+=(".env")
+fi
+
 # Upload files to remote server
 echo "📤 Uploading files to $SSH_USER@$SSH_HOST:$PROJECT_PATH/"
 scp -i "$DEPLOY_KEY_PATH" \


### PR DESCRIPTION
### 🚀 Summary of Changes

- **Added support for setting environment variables using the `env_vars` input**
  - This creates a `.env` file from the provided values and uploads it with the deployment files
  - Currently works with Docker Compose only (not yet supported for Docker Stack)

- **Fixed an issue where the Docker Compose file wasn’t being backed up correctly**
  - Caused by a problem with the file path, which has now been resolved

- These changes make deployments more flexible and allow environment settings to be managed without hardcoding values

- The input documentation has been updated to include the new `env_vars` option and its usage